### PR TITLE
Add possibility to authorized external access token to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,43 @@ The service expects authentication service information at $ISSUER_URL/.well-know
 
 See [JSON schema](schemas/qwc-oidc-auth.json) for optional configuration options.
 
+#### Configure Access Token endpoint
+
+It is possible to authorize connection with a external Access Token in  the Authorization Header (endpoint /tokenlogin).
+
+For each token a configuration need to be add in `authorized_api_token`.
+
+Example:
+```json
+{
+  "$schema": "https://github.com/qwc-services/qwc-oidc-auth/raw/main/schemas/qwc-oidc-auth.json",
+  "service": "oidc-auth",
+  "config": {
+    "issuer_url": "https://qwc2-dev.onelogin.com/oidc/2",
+    "client_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxxxxx",
+    "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "authorized_api_token": [{
+      "keys_url": "https://public_keys_url_to_decode_token",
+      "claims_options":{
+        "iss": {
+            "essential": true,
+            "values": ["https://example.com", "https://example.org"]
+        },
+        "sub": {
+            "essential": true,
+            "value": "xxxxxxxxxxxxx"
+        },
+        "aud": {
+          "essential": true,
+          "value": "api://xxxx-xxxxxxxxx-xxxxx"
+        }
+      }
+    }]
+  }
+}
+```
+
+`claims_options` are the token validation parameters which allow fine control over the content of the payload. This options following authlib specs : https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
 
 ### Identity provider configuration
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [JSON schema](schemas/qwc-oidc-auth.json) for optional configuration options
 
 It is possible to authorize connection with a external Access Token in  the Authorization Header (endpoint `/tokenlogin`).
 
-For each token a configuration need to be add in `authorized_api_token`.
+For each token a configuration needs to be add in `authorized_api_token`.
 
 Example:
 ```json

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [JSON schema](schemas/qwc-oidc-auth.json) for optional configuration options
 
 #### Configure Access Token endpoint
 
-It is possible to authorize connection with a external Access Token in  the Authorization Header (endpoint /tokenlogin).
+It is possible to authorize connection with a external Access Token in  the Authorization Header (endpoint `/tokenlogin`).
 
 For each token a configuration need to be add in `authorized_api_token`.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Example:
 }
 ```
 
-`claims_options` are the token validation parameters which allow fine control over the content of the payload. See {https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation}.
+`claims_options` are the token validation parameters which allow fine control over the content of the payload. See https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation.
 
 ### Identity provider configuration
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Example:
 }
 ```
 
-`claims_options` are the token validation parameters which allow fine control over the content of the payload. This options following authlib specs : https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation
+`claims_options` are the token validation parameters which allow fine control over the content of the payload. See {https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation}.
 
 ### Identity provider configuration
 

--- a/schemas/qwc-oidc-auth.json
+++ b/schemas/qwc-oidc-auth.json
@@ -49,7 +49,24 @@
         "groupinfo": {
           "description": "Attribute name of group memberships",
           "type": "string"
-        }
+        },
+        "authorized_api_token": {
+          "description": "List of api token authorized to use tokenlogin endpoint",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "keys_url": {
+                "description": "Public keys URL to decode token",
+                "type": "string"
+              },
+              "claims_options":{
+                "description": "Token validation parameters following authlib specs : https://docs.authlib.org/en/latest/jose/jwt.html#jwt-payload-claims-validation",
+                "type": "object"
+              }
+            }
+          }
+        }          
       },
       "required": [
         "issuer_url", "client_id", "client_secret"


### PR DESCRIPTION
Hi,

I am Benoit Ducarouge and I work in Oslandia. For the purposes of a client project we need to be able to connect to QWC2 (configured with the OIDC service) from QGIS.

This PR allows you to authorize a QWC2 connection from an Access Token obtained from QGIS (OAuth2 configuration).

The QWC2 JWT Token is seen here as a protected resource and the Access Token received is validated according to the specifications of the Authlib library: https://docs.authlib.org/en/latest/jose/jwt.html#jwt- payload-claims-validation.

The implementation and configuration of the OIDC service makes it possible to authorize several Access Tokens potentially from different authorities with fine control over the content of the payload.

I am open to comments and recommendations if you feel that this is not the right way to do it.

This PR has been tested and is functional with Keycloack and Azure.

Thank you in advance for your feedback.