### PR TITLE
fix: check if additional_userinfo has value before log

### DIFF
--- a/src/oidc_auth.py
+++ b/src/oidc_auth.py
@@ -132,7 +132,8 @@ class OIDCAuth:
         self.logger.info(f"User infos from ID Token : {userinfo}")
         # userinfo from UserInfo Endpoint
         additional_userinfo = self._oidc.userinfo(token=token)
-        self.logger.info(f"User infos from Endpoint : {additional_userinfo}")
+        if additional_userinfo:
+            self.logger.info(f"User infos from Endpoint : {additional_userinfo}")
         # {
         #   "userinfo": {
         #     "at_hash": "3lI-Bs8Ym0SmXLpEM6Idqw",


### PR DESCRIPTION
Hi,

This should be enough to fix #12 

If you don't want to use configDB, you need to set an empty string to `db_url` parameter in `oidcAuth` input config.

cc @rsrg-zwiama

I will create release asap

Thanks